### PR TITLE
feat: add THT coin configuration for Oraichain with contract address …

### DIFF
--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -278,6 +278,15 @@
       "coinDecimals": 6,
       "type": "cw20",
       "coinImageUrl": "https://i.imgur.com/JEUjDal.jpeg"
+    },
+    {
+      "coinDenom": "THT",
+      "coinGeckoId": "polkadot",
+      "coinMinimalDenom": "cw20:orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re:THT",
+      "contractAddress": "orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re",
+      "coinDecimals": 6,
+      "type": "cw20",
+      "coinImageUrl": "https://i.imgur.com/28ZtBo3.jpeg"
     }
   ]
 }

--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -269,6 +269,15 @@
       "bridgeTo": ["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],
       "coinDecimals": 6,
       "coinImageUrl": "https://pump.mypinata.cloud/ipfs/QmcGwYebsQfYbNSM9QDAMS2wKZ8fZNEiMbezJah1zgEWWS?img-width=256&img-dpr=2"
+    },
+    {
+      "coinDenom": "THT",
+      "coinGeckoId": "polkadot",
+      "coinMinimalDenom": "cw20:orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re:THT",
+      "contractAddress": "orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re",
+      "coinDecimals": 6,
+      "type": "cw20",
+      "coinImageUrl": "https://i.imgur.com/28ZtBo3.jpeg"
     }
   ]
 }

--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -278,15 +278,6 @@
       "coinDecimals": 6,
       "type": "cw20",
       "coinImageUrl": "https://i.imgur.com/JEUjDal.jpeg"
-    },
-    {
-      "coinDenom": "THT",
-      "coinGeckoId": "polkadot",
-      "coinMinimalDenom": "cw20:orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re:THT",
-      "contractAddress": "orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re",
-      "coinDecimals": 6,
-      "type": "cw20",
-      "coinImageUrl": "https://i.imgur.com/28ZtBo3.jpeg"
     }
   ]
 }


### PR DESCRIPTION
This pull request includes an update to the `chains/Oraichain.json` file to add a new coin to the list of supported coins.

Additions to the `chains/Oraichain.json` file:

* Added a new coin with the denomination "THT", including its `coinGeckoId`, `coinMinimalDenom`, `contractAddress`, `coinDecimals`, `type`, and `coinImageUrl`.