### PR TITLE
feat: add TON chain configuration and update schema for new coin types

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -352,17 +352,11 @@
           "type": "string"
         }
       },
-      "required": [
-        "coinDecimals",
-        "coinDenom",
-        "coinMinimalDenom",
-        "contractAddress",
-        "type"
-      ],
+      "required": ["coinDecimals", "coinDenom", "coinMinimalDenom", "contractAddress", "type"],
       "type": "object"
     },
     "CoinType": {
-      "enum": [0, 118, 195, 60],
+      "enum": [0, 118, 195, 60, 607],
       "type": "number"
     },
     "Currency": {
@@ -415,13 +409,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "coinDecimals",
-        "coinDenom",
-        "coinMinimalDenom",
-        "contractAddress",
-        "type"
-      ],
+      "required": ["coinDecimals", "coinDenom", "coinMinimalDenom", "contractAddress", "type"],
       "type": "object"
     },
     "EVMInfo": {
@@ -652,7 +640,7 @@
       "type": "object"
     },
     "NetworkType": {
-      "enum": ["bitcoin", "bsc", "cosmos", "evm", "tron"],
+      "enum": ["bitcoin", "bsc", "cosmos", "evm", "tron", "ton"],
       "type": "string"
     },
     "Secret20Currency": {
@@ -805,14 +793,6 @@
       "type": "string"
     }
   },
-  "required": [
-    "bip44",
-    "chainId",
-    "chainName",
-    "coinType",
-    "currencies",
-    "networkType",
-    "rpc"
-  ],
+  "required": ["bip44", "chainId", "chainName", "coinType", "currencies", "networkType", "rpc"],
   "type": "object"
 }

--- a/chains/ton.json
+++ b/chains/ton.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../chain.schema.json",
+  "rpc": "https://toncenter.com/api/v2/jsonRPC",
+  "rest": "https://toncenter.com/api/v2/jsonRPC",
+  "chainId": "ton",
+  "chainName": "TON",
+  "bip44": {
+    "coinType": 607
+  },
+  "coinType": 607,
+  "stakeCurrency": {
+    "coinDenom": "TON",
+    "coinMinimalDenom": "ton",
+    "coinDecimals": 9,
+    "coinGeckoId": "the-open-network",
+    "coinImageUrl": "https://assets.coingecko.com/coins/images/17980/standard/ton_symbol.png"
+  },
+  "bech32Config": {
+    "bech32PrefixAccAddr": "ton",
+    "bech32PrefixAccPub": "tonpub",
+    "bech32PrefixValAddr": "tonvaloper",
+    "bech32PrefixValPub": "tonvaloperpub",
+    "bech32PrefixConsAddr": "tonvalcons",
+    "bech32PrefixConsPub": "tonvalconspub"
+  },
+  "networkType": "ton",
+  "currencies": [
+    {
+      "coinDenom": "TON",
+      "coinMinimalDenom": "ton",
+      "coinDecimals": 9,
+      "bridgeTo": ["Oraichain"],
+      "prefixToken": "ton20_",
+      "contractAddress": "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c",
+      "coinGeckoId": "the-open-network",
+      "coinImageUrl": "https://assets.coingecko.com/coins/images/17980/standard/ton_symbol.png"
+    },
+    {
+      "coinDenom": "USDT",
+      "coinMinimalDenom": "ton20_usdt",
+      "coinDecimals": 6,
+      "bridgeTo": ["Oraichain"],
+      "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+      "prefixToken": "ton20_",
+      "coinGeckoId": "tether",
+      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/825.png"
+    },
+    {
+      "coinDenom": "HMSTR",
+      "coinMinimalDenom": "ton20_hamster_kombat",
+      "coinDecimals": 9,
+      "bridgeTo": ["Oraichain"],
+      "contractAddress": "EQAJ8uWd7EBqsmpSWaRdf_I-8R8-XHwh3gsNKhy-UrdrPcUo",
+      "prefixToken": "ton20_",
+      "coinGeckoId": "hamster-kombat",
+      "coinImageUrl": "https://assets.coingecko.com/coins/images/39102/standard/hamster-removebg-preview.png?1720514486"
+    },
+    {
+      "coinDenom": "jUSDC",
+      "coinMinimalDenom": "ton20_usdc",
+      "coinDecimals": 6,
+      "bridgeTo": ["Oraichain"],
+      "contractAddress": "EQB-MPwrd1G6WKNkLz_VnV6WqBDd142KMQv-g1O-8QUA3728",
+      "prefixToken": "ton20_",
+      "coinGeckoId": "usd-coin",
+      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/3408.png"
+    }
+  ],
+  "feeCurrencies": [
+    {
+      "coinDenom": "BTC",
+      "coinMinimalDenom": "btc",
+      "coinDecimals": 8,
+      "coinGeckoId": "bitcoin",
+      "coinImageUrl": "https://assets.coingecko.com/coins/images/1/small/bitcoin.png"
+    }
+  ],
+  "features": ["isTon"],
+  "txExplorer": {
+    "name": "BlockStream",
+    "txUrl": "https://tonviewer.com/transaction/{txHash}",
+    "accountUrl": "https://tonviewer.com/transaction/{address}"
+  }
+}


### PR DESCRIPTION
This pull request includes several changes to the `chain.schema.json` file and the addition of a new JSON file for the TON network. The main focus is on updating schema requirements and expanding the list of supported network types and coin types.

Schema updates:

* [`chain.schema.json`](diffhunk://#diff-9b02707c86085ca9490c443fad89463dcf8e04fcd4043a6a638f1cc95823b69eL355-R359): Modified the `required` fields format to a single line for several objects. [[1]](diffhunk://#diff-9b02707c86085ca9490c443fad89463dcf8e04fcd4043a6a638f1cc95823b69eL355-R359) [[2]](diffhunk://#diff-9b02707c86085ca9490c443fad89463dcf8e04fcd4043a6a638f1cc95823b69eL418-R412) [[3]](diffhunk://#diff-9b02707c86085ca9490c443fad89463dcf8e04fcd4043a6a638f1cc95823b69eL808-R796)
* [`chain.schema.json`](diffhunk://#diff-9b02707c86085ca9490c443fad89463dcf8e04fcd4043a6a638f1cc95823b69eL355-R359): Added `607` to the `CoinType` enum.
* [`chain.schema.json`](diffhunk://#diff-9b02707c86085ca9490c443fad89463dcf8e04fcd4043a6a638f1cc95823b69eL655-R643): Added `ton` to the `NetworkType` enum.

New network addition:

* [`chains/ton.json`](diffhunk://#diff-d9b4a517a72093e84b2a2d8f880daaefc47e6c1e5c7a8ef24521a4731b0e4846R1-R84): Added a new JSON file for the TON network, including details such as `rpc`, `chainId`, `chainName`, `currencies`, and `feeCurrencies`.