### PR TITLE
refactor: remove legacy BTC.legacy entry from Oraichain.json

### DIFF
--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -183,7 +183,8 @@
       "coinGeckoId": "injective-protocol",
       "coinMinimalDenom": "ibc/49D820DFDE9F885D7081725A58202ABA2F465CAEE4AFBC683DFB79A8E013E83E",
       "coinDecimals": 18,
-      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/7226.png"
+      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/7226.png",
+      "isDisableddSwap": true
     },
     {
       "coinDenom": "INJ",
@@ -206,10 +207,22 @@
       "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png"
     },
     {
+      "coinDenom": "BTC.legacy",
+      "coinGeckoId": "bitcoin",
+      "coinMinimalDenom": "usat",
+      "type": "cw20",
+      "contractAddress": "orai10g6frpysmdgw5tdqke47als6f97aqmr8s3cljsvjce4n5enjftcqtamzsd",
+      "coinDecimals": 6,
+      "bridgeTo": ["bitcoin"],
+      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/1.png",
+      "isDisableddSwap": true
+    },
+    {
       "coinDenom": "BTC",
       "coinMinimalDenom": "factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/obtc",
       "coinDecimals": 14,
       "coinGeckoId": "bitcoin",
+      "bridgeTo": ["bitcoin"],
       "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/1.png"
     },
     {
@@ -242,7 +255,8 @@
       "coinGeckoId": "hamster-kombat",
       "coinMinimalDenom": "factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/HMSTR",
       "coinDecimals": 9,
-      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/32195.png"
+      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/32195.png",
+      "bridgeTo": ["ton"]
     },
     {
       "coinDenom": "DOGE",
@@ -267,6 +281,14 @@
       "bridgeTo": ["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],
       "coinDecimals": 6,
       "coinImageUrl": "https://pump.mypinata.cloud/ipfs/QmcGwYebsQfYbNSM9QDAMS2wKZ8fZNEiMbezJah1zgEWWS?img-width=256&img-dpr=2"
+    },
+    {
+      "coinDenom": "TON",
+      "coinMinimalDenom": "factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/ton",
+      "coinDecimals": 9,
+      "bridgeTo": ["ton", "osmosis-1"],
+      "coinGeckoId": "the-open-network",
+      "coinImageUrl": "https://assets.coingecko.com/coins/images/17980/standard/ton_symbol.png?1696517498"
     }
   ]
 }

--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -206,16 +206,6 @@
       "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png"
     },
     {
-      "coinDenom": "BTC.legacy",
-      "coinGeckoId": "bitcoin",
-      "coinMinimalDenom": "usat",
-      "type": "cw20",
-      "contractAddress": "orai10g6frpysmdgw5tdqke47als6f97aqmr8s3cljsvjce4n5enjftcqtamzsd",
-      "coinDecimals": 6,
-      "bridgeTo": ["bitcoin"],
-      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/1.png"
-    },
-    {
       "coinDenom": "BTC",
       "coinMinimalDenom": "factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/obtc",
       "coinDecimals": 14,

--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -179,6 +179,13 @@
       "coinImageUrl": "https://assets.coingecko.com/coins/images/33050/standard/orchai_logo_white_copy_4x-8_%281%29.png?1700473937"
     },
     {
+      "coinDenom": "IBC INJ",
+      "coinGeckoId": "injective-protocol",
+      "coinMinimalDenom": "ibc/49D820DFDE9F885D7081725A58202ABA2F465CAEE4AFBC683DFB79A8E013E83E",
+      "coinDecimals": 18,
+      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/7226.png"
+    },
+    {
       "coinDenom": "INJ",
       "coinGeckoId": "injective-protocol",
       "coinMinimalDenom": "injective",

--- a/chains/Oraichain.json
+++ b/chains/Oraichain.json
@@ -179,13 +179,6 @@
       "coinImageUrl": "https://assets.coingecko.com/coins/images/33050/standard/orchai_logo_white_copy_4x-8_%281%29.png?1700473937"
     },
     {
-      "coinDenom": "IBC INJ",
-      "coinGeckoId": "injective-protocol",
-      "coinMinimalDenom": "ibc/49D820DFDE9F885D7081725A58202ABA2F465CAEE4AFBC683DFB79A8E013E83E",
-      "coinDecimals": 18,
-      "coinImageUrl": "https://s2.coinmarketcap.com/static/img/coins/64x64/7226.png"
-    },
-    {
       "coinDenom": "INJ",
       "coinGeckoId": "injective-protocol",
       "coinMinimalDenom": "injective",


### PR DESCRIPTION
This pull request includes several updates to the `chains/Oraichain.json` file, primarily involving the addition of new fields and entries for various coins. The most important changes include adding the `isDisableddSwap` field to multiple coin entries, adding new `bridgeTo` values, and introducing a new coin entry for "TON".

Key updates:

* Added `isDisableddSwap` field:
  * Added `"isDisableddSwap": true` to the coin entries with `coinMinimalDenom` values of `ibc/49D820DFDE9F885D7081725A58202ABA2F465CAEE4AFBC683DFB79A8E013E83E` and `orai10g6frpysmdgw5tdqke47als6f97aqmr8s3cljsvjce4n5enjftcqtamzsd`. [[1]](diffhunk://#diff-80d42e38e60c156b3371d613f668717467843abcbc85bc233779b9a3f01ea8a7L186-R187) [[2]](diffhunk://#diff-80d42e38e60c156b3371d613f668717467843abcbc85bc233779b9a3f01ea8a7L216-R225)

* Added new `bridgeTo` values:
  * Added `"bridgeTo": ["bitcoin"]` to the coin entry with `coinMinimalDenom` value of `factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/obtc`.
  * Added `"bridgeTo": ["ton"]` to the coin entry with `coinMinimalDenom` value of `factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/HMSTR`.

* Introduced new coin entry:
  * Added a new coin entry for "TON" with details including `coinMinimalDenom`, `coinDecimals`, `bridgeTo`, `coinGeckoId`, and `coinImageUrl`.This pull request includes a change to the `chains/Oraichain.json` file, focusing on the removal of a specific coin entry.

Changes to `chains/Oraichain.json`:

* Removed the `BTC.legacy` coin entry, which included details such as `coinDenom`, `coinGeckoId`, `coinMinimalDenom`, `type`, `contractAddress`, `coinDecimals`, `bridgeTo`, and `coinImageUrl`.